### PR TITLE
Last change variation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2 (, 2016)
+    - Added cool down and bid threshold times in the configuration file
+    - Refresh state doesn't affect tiopatinhas' actions anymore
+
 ## 1.0.1 (November 29, 2016)
     - Added support to get user data from Launch Configuration Group if not provided
 

--- a/tp/tp.conf.template
+++ b/tp/tp.conf.template
@@ -13,6 +13,8 @@
     "placement": "us-east-1a",
     "instance_profile_name": null,
     "monitoring_enabled": false,
+    "cool_down_threshold": 360,
+    "bid_threshold": 300,
     "tags": {},
     "user_data_file": null
 }

--- a/tp/tp.py
+++ b/tp/tp.py
@@ -432,12 +432,12 @@ class TPManager:
                     self.attach_instance(instance.id, "OD")
 
     def stop(self):
-        ''' Prepares this TPManager to stop by not launching new machines
+        """ Prepares this TPManager to stop by not launching new machines
             and gradually remove old machines.
 
             This manager loop will only stop when both the autoscaling group
             and the TP manager has zero instances running.
-        '''
+        """
         self.started = False
 
     def start(self):

--- a/tp/tp.py
+++ b/tp/tp.py
@@ -240,21 +240,21 @@ class TPManager:
             instance_profile_name=self.instance_profile_name,
             monitoring_enabled=self.monitoring_enabled)
 
-        # get reserve since count is 1
-        reserve = request[0]
+        # get the first reservation since count is 1
+        reservation = request[0]
 
         # get the status
-        status = reserve.status
+        status = reservation.status
 
         # check for the status while it isn't running
         while status.code != 'fulfilled':
-            self.logger.info("Instance status = %s", status.code)
+            self.logger.info("Reservation status = %s", status.code)
             time.sleep(5)
-            status = self.ec2.get_all_spot_instance_requests(request_ids=[reserve.id])[0].status
+            status = self.ec2.get_all_spot_instance_requests(request_ids=[reservation.id])[0].status
 
-        # when it's finally running, update the tag
-        self.logger.info("Instance status = %s", status.code)
-        reserve.add_tag('tp:tag', self.side_group)
+        # when it's finally fulfilled, update the tag
+        self.logger.info("Reservation status = %s", status.code)
+        reservation.add_tag('tp:tag', self.side_group)
 
         self.logger.info(">> bid(): created 1 bid of %s for %s", self.spot_type, self.max_price[self.spot_type])
         self.last_bid = time.time()

--- a/tp/tp.py
+++ b/tp/tp.py
@@ -240,20 +240,21 @@ class TPManager:
             instance_profile_name=self.instance_profile_name,
             monitoring_enabled=self.monitoring_enabled)
 
-        # get instance since count is 1
-        instance = request.instances[0]
+        # get reserve since count is 1
+        reserve = request[0]
 
         # get the status
-        status = instance.update()
+        status = reserve.status
 
         # check for the status while it isn't running
-        while status != 'running':
+        while status.code != 'fulfilled':
+            self.logger.info("Instance status = %s", status.code)
             time.sleep(5)
-            status = instance.update()
+            status = self.ec2.get_all_spot_instance_requests(request_ids=[reserve.id])[0].status
 
         # when it's finally running, update the tag
-        self.logger.info("Instance status = " + status)
-        instance.add_tag('tp:tag', self.side_group)
+        self.logger.info("Instance status = %s", status.code)
+        reserve.add_tag('tp:tag', self.side_group)
 
         self.logger.info(">> bid(): created 1 bid of %s for %s", self.spot_type, self.max_price[self.spot_type])
         self.last_bid = time.time()


### PR DESCRIPTION
Motivation of this minor update:
- Refresh state was updating the `last_change` variable, delaying tiopatinhas actions. Thus if the ASG is changing a lot, tiopatinhas could be idle without updating its `target` number of machines for quite some time.
- This could make sense to avoid flapping, however when scaling down , this behavior leads to situation when there's more tiopatinhas than on-demand machines.

Solution (or at least, a proposal):
- Remove the `last_change` update of the refresh state method. This will make tiopatinhas to act more quickly.
- Add parameters to cool down and bid threshold. This will make the user says how frequently it wants to bid machines, demote and promote machines (The `target` will only be updated every `cool_down_threshold` seconds and will bid whenever there is the need for a bid and the last bid was more than `bid_threshold` seconds).
