### PR TITLE
Get user data from Launch Configuration Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ currently supports the following properties:
 #### Optional properties
 * *tags:* A map containing custom metadata tags that must assigned to TP instances. *(optional)*
     * more info: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html
-* *user_data_file:* An optional script or data that must be supplied to the instance on startup. *(optional)*
+* *user_data_file:* An optional script or data that will be supplied to the instance on startup.
+  If not provided, it will try to get from the Launch Configuration Group. *(optional)*
     * more info: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html
 * *subnet_id:* The VPC's subnet id that will be used by instances TP will manage. *(optional)*
     * more info: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Subnets.html

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ use debian or ubuntu you can install it by typing: 'sudo pip install boto'.
 2. Make sure your AWS credentials are specified in a boto configuration file
 (typically ~/.boto). Instruction on how to setup this file can be found here:
 https://code.google.com/p/boto/wiki/BotoConfig
+3. To run the setup, you may need to install [setuptools](https://setuptools.readthedocs.io/en/latest/)
 
 ### Configuring tiopatinhas ###
 

--- a/tp/tp.py
+++ b/tp/tp.py
@@ -123,7 +123,7 @@ class TPManager:
             self.logger.warn("Could not read user from launch configuration group: %s."
                              "Will launch instances without user data.", self.tapping_group.lc.name)
 
-        self.logger.info("User data: %s", self.user_data)
+        self.logger.info("User data: \n%s", self.user_data)
 
     def refresh(self):
         self.tapping_group = AutoScaleInfo(self.side_group, self.region)

--- a/tp/tp.py
+++ b/tp/tp.py
@@ -108,7 +108,7 @@ class TPManager:
         self.user_data = user_data
         user_data_file = self.conf.get("user_data_file", None)
         if not user_data and user_data_file:
-            self.logger.info("trying to user data from file...")
+            self.logger.info("Trying to user data from file...")
             try:
                 with open(user_data_file) as f:
                     self.user_data = f.read()
@@ -117,11 +117,13 @@ class TPManager:
                                  user_data_file)
 
         if not user_data and not user_data_file and self.tapping_group.user_data:
-            self.logger.info("trying to user data from launch configuration group...")
+            self.logger.info("Trying to user data from launch configuration group...")
             self.user_data = self.tapping_group.user_data
         else:
             self.logger.warn("Could not read user from launch configuration group: %s."
                              "Will launch instances without user data.", self.tapping_group.lc.name)
+
+        self.logger.info("User data: %s", self.user_data)
 
     def refresh(self):
         self.tapping_group = AutoScaleInfo(self.side_group, self.region)

--- a/tp/tp.py
+++ b/tp/tp.py
@@ -106,9 +106,10 @@ class TPManager:
         self.elb = boto.ec2.elb.connect_to_region(self.region)
 
         self.user_data = user_data
-        user_data_file = self.conf.get("user_data_file", None)
-        if not user_data and user_data_file:
-            self.logger.info("Trying to user data from file...")
+
+        if not self.user_data:
+            user_data_file = self.conf.get("user_data_file", None)
+            self.logger.info("Trying to get user data from file...")
             try:
                 with open(user_data_file) as f:
                     self.user_data = f.read()
@@ -116,10 +117,11 @@ class TPManager:
                 self.logger.warn("Could not read user data file: %s. Will launch instances without user data.",
                                  user_data_file)
 
-        if not user_data and not user_data_file and self.tapping_group.user_data:
-            self.logger.info("Trying to user data from launch configuration group...")
+        if not self.user_data:
+            self.logger.info("Trying to get user data from launch configuration group...")
             self.user_data = self.tapping_group.user_data
-        else:
+
+        if not self.user_data:
             self.logger.warn("Could not read user from launch configuration group: %s."
                              "Will launch instances without user data.", self.tapping_group.lc.name)
 

--- a/tp/tp.py
+++ b/tp/tp.py
@@ -108,6 +108,7 @@ class TPManager:
         self.user_data = user_data
         user_data_file = self.conf.get("user_data_file", None)
         if not user_data and user_data_file:
+            self.logger.info("trying to user data from file...")
             try:
                 with open(user_data_file) as f:
                     self.user_data = f.read()
@@ -116,6 +117,7 @@ class TPManager:
                                  user_data_file)
 
         if not user_data and not user_data_file and self.tapping_group.user_data:
+            self.logger.info("trying to user data from launch configuration group...")
             self.user_data = self.tapping_group.user_data
         else:
             self.logger.warn("Could not read user from launch configuration group: %s."

--- a/tp/tp.py
+++ b/tp/tp.py
@@ -21,8 +21,10 @@ logging.basicConfig(format='%(asctime)s %(name)s %(levelname)s %(message)s')
 logger = logging.getLogger("main")
 logger.setLevel(logging.DEBUG)
 
+
 class AutoScaleInfoException(Exception):
     pass
+
 
 class AutoScaleInfo:
     def __init__(self, autoscale_group_name, region):
@@ -44,10 +46,10 @@ class AutoScaleInfo:
         self.instance_type = self.lc.instance_type
         self.image_id = self.lc.image_id
         self.security_groups = self.lc.security_groups
+        self.user_data = self.lc.user_data
 
         self.load_balancers = self.ag.load_balancers
         self.desired_capacity = self.ag.desired_capacity
-
 
     def __repr__(self):
         return "<AutoScaleInfo Group:%s>" % self.name
@@ -78,7 +80,7 @@ class TPManager:
         self.weight_factor = weight_factor
         self.tags = self.conf.get("tags", {})
         self.instance_profile_name = self.conf.get("instance_profile_name", None)
-        self.region = region or self.conf.get("region", "us-east-1") #parameter has precedence over config file
+        self.region = region or self.conf.get("region", "us-east-1")  # parameter has precedence over config file
         self.subnet_id = self.conf.get("subnet_id", None)
         self.monitoring_enabled = self.conf.get("monitoring_enabled", False)
 
@@ -113,6 +115,12 @@ class TPManager:
                 self.logger.warn("Could not read user data file: %s. Will launch instances without user data.",
                                  user_data_file)
 
+        if not user_data and not user_data_file and self.tapping_group.user_data:
+            self.user_data = self.tapping_group.user_data
+        else:
+            self.logger.warn("Could not read user from launch configuration group: %s."
+                             "Will launch instances without user data.", self.tapping_group.lc.name)
+
     def refresh(self):
         self.tapping_group = AutoScaleInfo(self.side_group, self.region)
         self.guess_target()
@@ -125,7 +133,7 @@ class TPManager:
 
     def guess_target(self):
         if not self.started:
-            self.target = min(self.managed_instances(), self.managed_by_autoscale()) # follow autoscale if stopped :)
+            self.target = min(self.managed_instances(), self.managed_by_autoscale())  # follow autoscale if stopped :)
             return
 
         if self.target == None:
@@ -174,13 +182,13 @@ class TPManager:
 
         ami = self.ec2.get_image(tapping_group.image_id)
         for c in range(amount):
-            r = ami.run(security_group_ids = tapping_group.security_groups,
-                    instance_type = self.emergency_type,
-                    instance_profile_name = self.instance_profile_name,
-                    placement = self.placement,
-                    subnet_id = self.subnet_id,
-                    user_data = self.user_data,
-                    monitoring_enabled = self.monitoring_enabled)
+            r = ami.run(security_group_ids=tapping_group.security_groups,
+                        instance_type=self.emergency_type,
+                        instance_profile_name=self.instance_profile_name,
+                        placement=self.placement,
+                        subnet_id=self.subnet_id,
+                        user_data=self.user_data,
+                        monitoring_enabled=self.monitoring_enabled)
             self.logger.info(">> buy(): purchased 1 on-demand instance")
             time.sleep(3)
             instance = r.instances[0]
@@ -204,17 +212,17 @@ class TPManager:
         tapping_group = self.tapping_group
 
         request = self.ec2.request_spot_instances(
-                price = self.max_price[self.spot_type],
-                image_id = tapping_group.image_id,
-                count = 1,
-                type = "one-time",
-                placement = self.placement,
-                security_group_ids = tapping_group.security_groups,
-                subnet_id = self.subnet_id,
-                user_data = self.user_data,
-                instance_type = self.spot_type,
-                instance_profile_name = self.instance_profile_name,
-                monitoring_enabled = self.monitoring_enabled)
+            price=self.max_price[self.spot_type],
+            image_id=tapping_group.image_id,
+            count=1,
+            type="one-time",
+            placement=self.placement,
+            security_group_ids=tapping_group.security_groups,
+            subnet_id=self.subnet_id,
+            user_data=self.user_data,
+            instance_type=self.spot_type,
+            instance_profile_name=self.instance_profile_name,
+            monitoring_enabled=self.monitoring_enabled)
         # TODO really?
         while 1:
             try:
@@ -281,8 +289,8 @@ class TPManager:
         for instance in self.emergency:
             self.logger.debug("proximity(%s): %s", instance.id, str(self.proximity(instance)))
             if (self.proximity(instance) < 10
-                    and self.proximity(instance) > 2
-                    and self.managed_instances() <= self.target):
+                and self.proximity(instance) > 2
+                and self.managed_instances() <= self.target):
                 self.logger.info(">> maybe_replace(): attempting to replace %s", instance.id)
                 self.bid(force=True)
 
@@ -396,7 +404,7 @@ class TPManager:
         instances = chain.from_iterable(all_instances)
         for instance in instances:
             if (instance.tags.get('tp:group', None) == self.tapping_group.name and
-                    instance.state not in ('terminated', 'shutting-down')):
+                        instance.state not in ('terminated', 'shutting-down')):
                 self.emergency.append(instance)
                 if instance.id not in running_in_lb:
                     self.logger.info(">> load_state: Attaching new emergency instance %s to LB." % instance.id)
@@ -419,7 +427,7 @@ class TPManager:
         self.logger.debug("Managed by Autoscale: " + str(self.managed_by_autoscale()))
         self.logger.debug("Managed by TP: " + str(self.managed_instances()))
         self.logger.debug("Target: " + str(self.target))
-        self.logger.debug("Live: " +  ", ".join([x.instance_id for x in self.live]))
+        self.logger.debug("Live: " + ", ".join([x.instance_id for x in self.live]))
         self.logger.debug("Emergency: " + ", ".join([x.id for x in self.emergency]))
         self.logger.debug("LB Unhealthy: " + ", ".join(self.unhealthy_ids))
 
@@ -470,9 +478,11 @@ class TPManager:
         self.maybe_demote()
         self.previous_managed = self.live_or_emergency()
 
+
 def flush_output():
     sys.stdout.flush()
     sys.stderr.flush()
+
 
 def daemonize():
     pid = os.fork()
@@ -495,8 +505,10 @@ def daemonize():
     os.dup2(out.fileno(), sys.stdout.fileno())
     os.dup2(err.fileno(), sys.stderr.fileno())
 
+
 if __name__ == '__main__':
     import getopt
+
 
     def usage():
         print """\
@@ -510,6 +522,7 @@ availability's group load balancer.
    -d, --daemonize                 Detach from the terminal
    -v, --verbose                   Verbose mode
 """
+
 
     try:
         opts, args = getopt.getopt(sys.argv[1:], "g:dv", ["group=", "daemonize", "verbose"])


### PR DESCRIPTION
Yo!

This is an enhancement to allow tiopatinhas to get the user data from the Launch Configuration Group used by the Auto Scaling Group that tiopatinhas is monitoring. So, it will first check the class initialization, then the user data file passed by the configuration file and then it will check the Launch Configuration Group if none of those values are configured.