### PR TITLE
Improve cool down

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Chaordic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ use Spot Instances in systems which are not fault tolerant.
 1. Make sure the boto python package is installed in your system. If you
 use debian or ubuntu you can install it by typing: 'sudo pip install boto'.
 2. Make sure your AWS credentials are specified in a boto configuration file
-(typically ~/.boto). Instruction on how to setup this file can be found here:
-https://code.google.com/p/boto/wiki/BotoConfig
+(typically ~/.boto). Instruction on how to setup this file can be found [here](https://code.google.com/p/boto/wiki/BotoConfig).
 3. To run the setup, you may need to install [setuptools](https://setuptools.readthedocs.io/en/latest/)
 
 ### Configuring tiopatinhas ###
@@ -60,15 +59,19 @@ currently supports the following properties:
 
 #### Optional properties
 * *tags:* A map containing custom metadata tags that must assigned to TP instances. *(optional)*
-    * more info: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html
+    * More information can be found [here](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html).
 * *user_data_file:* An optional script or data that will be supplied to the instance on startup.
   If not provided, it will try to get from the Launch Configuration Group. *(optional)*
-    * more info: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html
+    * More information can be found [here](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html).
 * *subnet_id:* The VPC's subnet id that will be used by instances TP will manage. *(optional)*
-    * more info: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Subnets.html
+    * More information can be found [here](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Subnets.html).
 * *monitoring_enabled:* There are two types of Monitoring: basic and detailed.
   You can enable or disable the detailed monitoring by setting this field to True or False. *(optional)*
-    * more info: https://aws.amazon.com/cloudwatch/details/#amazon-ec2-monitoring
+    * More information can be found [here](https://aws.amazon.com/cloudwatch/details/#amazon-ec2-monitoring).
+* *bid_threshold:* Time to wait before doing another spot bid to AWS. Defaults to 300 seconds.
+    * More information can be found [here](https://aws.amazon.com/ec2/spot/pricing/).
+* *cool_down_threshold:* Time to wait before updating tiopatinhas target again.
+  Target is the number of instances managed by the ASG. Defaults to 360 seconds.
 
 ### Coding with tiopatinhas  ###
 

--- a/README.md
+++ b/README.md
@@ -106,3 +106,7 @@ You may need to use `sudo` depending on your environment setup.
 * Once the tp/tp.conf file is ready, execute tiopatinhas with the following command:
     * _python tp.py -g \<AutoScalingGroupName\>_ (this command must currently be executed from within the "tp" folder)
 * You must optionally supply options "-v" for verbose mode or "-d" for daemon mode.
+
+## License
+
+tiopatinhas is available under the [MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ currently supports the following properties:
 
 * *spot_type:* The instance type to bid for in the spot market (recommended: the same instance from the ASG)
 * *emergency_type:* The instance type to buy in case of market crash (recommended: the same instance from the ASG)
+* *bid_threshold:* Time to wait before doing another spot bid to AWS. Defaults to 300 seconds.
+    * More information can be found [here](https://aws.amazon.com/ec2/spot/pricing/).
+* *cool_down_threshold:* Time to wait before doing another scale action again. Defaults to 360 seconds.
 
 #### Optional properties
 * *tags:* A map containing custom metadata tags that must assigned to TP instances. *(optional)*
@@ -68,10 +71,6 @@ currently supports the following properties:
 * *monitoring_enabled:* There are two types of Monitoring: basic and detailed.
   You can enable or disable the detailed monitoring by setting this field to True or False. *(optional)*
     * More information can be found [here](https://aws.amazon.com/cloudwatch/details/#amazon-ec2-monitoring).
-* *bid_threshold:* Time to wait before doing another spot bid to AWS. Defaults to 300 seconds.
-    * More information can be found [here](https://aws.amazon.com/ec2/spot/pricing/).
-* *cool_down_threshold:* Time to wait before updating tiopatinhas target again.
-  Target is the number of instances managed by the ASG. Defaults to 360 seconds.
 
 ### Coding with tiopatinhas  ###
 

--- a/tp/tp.py
+++ b/tp/tp.py
@@ -232,7 +232,7 @@ class TPManager:
     def bid(self, force=False):
         elapsed_time = time.time() - self.last_bid
         if not force and elapsed_time < self.bid_threshold:
-            self.logger.info("bid(): last change was too recent, skipping bid! Remaining time to next change %s",
+            self.logger.info(">> bid(): last bid was too recent, skipping bid! Remaining time to next change %s",
                              self.bid_threshold - elapsed_time)
             time.sleep(10)
             return
@@ -301,7 +301,7 @@ class TPManager:
             instance_info = self.ec2.get_all_instances(instance_ids=[instance_id])[0].instances[0]
             uptime = datetime.utcnow() - datetime.strptime(instance_info.launch_time, '%Y-%m-%dT%H:%M:%S.%fZ')
             if uptime > grace_period_delta:
-                self.logger.info(">> maybe_terminate(): %s is unhealthy_ids for longer than %s minutes - killing it!",
+                self.logger.info(">> maybe_terminate(): %s is unhealthy for longer than %s minutes - killing it!",
                                  instance_id, self.grace_period_minutes)
                 self.dettach_instance(instance_id)
                 self.ec2.terminate_instances([instance_id])
@@ -378,7 +378,7 @@ class TPManager:
 
         elapsed_time = time.time() - self.last_change
 
-        if elapsed_time > self.cool_down_threshold:
+        if elapsed_time <= self.cool_down_threshold:
             self.logger.info("Not removing any instances, waiting for cool down!"
                              " Remaining time to next change %s", self.cool_down_threshold - elapsed_time)
             return False

--- a/tp/tp.py
+++ b/tp/tp.py
@@ -451,9 +451,10 @@ class TPManager:
     def print_state(self):
         self.logger.debug("*** Current state:")
         self.logger.debug("Managed by Autoscale: " + str(self.managed_by_autoscale()))
-        self.logger.debug("Managed by TP: " + str(self.managed_instances()))
-        self.logger.debug("Target: " + str(self.target))
-        self.logger.debug("Live: " + ", ".join([x.instance_id for x in self.live]))
+        self.logger.debug("TP target: " + str(self.target))
+        self.logger.debug("Instances managed by TP: " + str(self.managed_instances()))
+        self.logger.debug("TP live instances: " + str(len(self.live)) + " [" +
+                          ", ".join([x.instance_id for x in self.live]) + "]")
         self.logger.debug("Emergency: " + ", ".join([x.id for x in self.emergency]))
         self.logger.debug("LB Unhealthy: " + ", ".join(self.unhealthy_ids))
 

--- a/tp/tp.py
+++ b/tp/tp.py
@@ -162,11 +162,7 @@ class TPManager:
         candidate = round(self.weight_factor * self.tapping_group.desired_capacity)
 
         # Never less than one
-        if candidate < 1:
-            candidate = 1
-
-        max_candidates = self.conf.get("max_candidates", 6)
-        candidate = min(candidate, max_candidates)
+        candidate = max(1, min(candidate, self.conf.get("max_candidates", 6)))
 
         if candidate != previous:
             self.logger.debug(">> guess_target(): changed target from %s to %s", previous, candidate)

--- a/tp/tp.py
+++ b/tp/tp.py
@@ -171,7 +171,6 @@ class TPManager:
 
         max_candidates = self.conf.get("max_candidates", 6)
         candidate = min(candidate, max_candidates)
-        self.logger.debug("Current candidate for target instances: %s", str(candidate))
 
         if candidate != previous:
             self.logger.debug(">> guess_target(): changed target from %s to %s", previous, candidate)


### PR DESCRIPTION
I'm proposing with this PR to remove the cool down threshold when updating TP target. This way the target will always match the ASG desired capacity. With this modification, I'm adding the cool down threshold to instance's promotion and demotion, still preventing tiopatinhas of "flapping". In a nutshell, this will allow tiopatinhas to act faster and avoiding adding instances to the cluster when the ASG desired capacity is already lower than it was. There are some minor fixes and corrections in this PR as well.